### PR TITLE
Fix/ashkenazi standard/fixes 2026 02 17

### DIFF
--- a/po/ashkenazi_standard.po
+++ b/po/ashkenazi_standard.po
@@ -20,7 +20,13 @@
 #     or at least lengthen the syllable. Ex. Ta'anis, Hosha'ano Rabo.
 #   - Sh'vo noch ends a syllable and is not spelled out.
 #     Ex. Tish[']o B'Ov.
-#   - Tzeire is spelled ei. Ex. Teiveis.
+#   - Tzeireh is spelled ei when either:
+#     1. the syllable continues into a soft, open letter
+#        like Alef, Hei, Vav (non-consonant) or Yud; or
+#     2. when most Ashkenaz speakers give the syllable the primary stress.
+#     Otherwise, it is spelled e.
+#     Ex. Kisle[i]v, Mike[i]tz, Vayakhe[i]l;
+#     but Teive[i]s, Beitzo, B'reishis, P'kudei.
 #   - Dipthongs into Yud spell the Yud with an i. Ex. Vaichi.
 #   - Cholom is spelled with an o. Ex. Bo, B'choros.
 #   - Komatz is spelled with an o,
@@ -30,7 +36,7 @@
 # # Consonants
 #
 #   - Oyin is not given any special symbol.
-#     Ex. [']Erev Pesach, [']Asoro B'Teiveis.
+#     Ex. [']Erev Pesach, [']Asoro B'Teives.
 #   - A final Hei is skipped.
 #     Ex. Avodo[h] Zoro[h], Chanuko[h], Rosh HaShono[h].
 #   - Sof is spelled with an s,
@@ -87,10 +93,10 @@ msgid "Arachin"
 msgstr "Arochin"
 
 msgid "Asara B'Tevet (Mincha)"
-msgstr "Asoro B'Teiveis (Mincho)"
+msgstr "Asoro B'Teives (Mincho)"
 
 msgid "Asara B'Tevet"
-msgstr "Asoro B'Teiveis"
+msgstr "Asoro B'Teives"
 
 msgid "Av"
 msgstr "Ov"
@@ -285,7 +291,7 @@ msgid "Kinnim"
 msgstr "Kinnim"
 
 msgid "Kislev"
-msgstr "Kisleiv"
+msgstr "Kislev"
 
 msgid "Korach"
 msgstr "Korach"
@@ -327,7 +333,7 @@ msgid "Midot"
 msgstr "Midos"
 
 msgid "Miketz"
-msgstr "Mikeitz"
+msgstr "Miketz"
 
 msgid "Mincha Gedolah"
 msgstr "Mincho G'dolo"
@@ -564,7 +570,7 @@ msgid "Ta'anit Bechorot"
 msgstr "Ta'anis B'choros"
 
 msgid "Ta'anit Esther"
-msgstr "Ta'anis Esteir"
+msgstr "Ta'anis Ester"
 
 msgid "Tamid"
 msgstr "Tomid"
@@ -588,7 +594,7 @@ msgid "Tetzaveh"
 msgstr "T'tzave"
 
 msgid "Tevet"
-msgstr "Teiveis"
+msgstr "Teives"
 
 msgid "Tefilah, sof zeman"
 msgstr "Sof Z'man T'fillo"
@@ -627,7 +633,7 @@ msgid "Vaetchanan"
 msgstr "Vo'eschanan"
 
 msgid "Vayakhel"
-msgstr "Vayakheil"
+msgstr "Vayakhel"
 
 msgid "Vayechi"
 msgstr "Vaichi"

--- a/po/ashkenazi_standard.po
+++ b/po/ashkenazi_standard.po
@@ -13,10 +13,10 @@
 #     unless already indicated with a letter casing change.
 #     Ex. Shovu'os, but Lag BoOmer.
 #   - If a vowel is lengthened by the same vowel
-#     or the m'chutof version of the same vowel,
-#     it is indicated with an intervening apostrophe, and not skipped,
-#     even if they are overwhelmingly not pronounced as separate syllables.
-#     Note that major Ashkenazic dialects will pronounce a'a as ai
+#     or the chatof version of the same vowel,
+#     it is indicated with an intervening apostrophe.
+#     It is not skipped, even if overwhelmingly pronounced as one syllable.
+#     Note that major Ashkenaz dialects will pronounce a'a as ai
 #     or at least lengthen the syllable. Ex. Ta'anis, Hosha'ano Rabo.
 #   - Sh'vo noch ends a syllable and is not spelled out.
 #     Ex. Tish[']o B'Ov.
@@ -61,7 +61,7 @@ msgstr ""
 "Project-Id-Version: hebcal 4.2\n"
 "Report-Msgid-Bugs-To: hebcal-bugs@sadinoff.com\n"
 "POT-Creation-Date: 2015-12-30 14:54-0500\n"
-"PO-Revision-Date: 2026-02-16 07:40-0700\n"
+"PO-Revision-Date: 2026-02-17 18:40-0700\n"
 "Language: ashkenazi_standard\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/po/ashkenazi_standard.po
+++ b/po/ashkenazi_standard.po
@@ -507,7 +507,7 @@ msgid "Shoftim"
 msgstr "Shoftim"
 
 msgid "Sh'vat"
-msgstr "Sh'vot"
+msgstr "Shvot"
 
 msgid "Shmini Atzeret"
 msgstr "Sh'mini Atzeres"
@@ -612,10 +612,10 @@ msgid "Tu B'Av"
 msgstr "Tu B'Ov"
 
 msgid "Tu BiShvat"
-msgstr "Tu BiSh'vot"
+msgstr "Tu BiShvot"
 
 msgid "Tu B'Shvat"
-msgstr "Tu BiSh'vot"
+msgstr "Tu BiShvot"
 
 msgid "Tzav"
 msgstr "Tzav"

--- a/po/ashkenazi_standard.po
+++ b/po/ashkenazi_standard.po
@@ -188,9 +188,6 @@ msgstr "Chatzos HaYom"
 msgid "Chatzot hayom"
 msgstr "Chatzos HaYom"
 
-msgid "Chatzot hayom"
-msgstr "Chatzos HaYom"
-
 msgid "Chayei Sara"
 msgstr "Chayei Soro"
 

--- a/po/ashkenazi_standard.po
+++ b/po/ashkenazi_standard.po
@@ -20,7 +20,7 @@
 #     or at least lengthen the syllable. Ex. Ta'anis, Hosha'ano Rabo.
 #   - Sh'vo noch ends a syllable and is not spelled out.
 #     Ex. Tish[']o B'Ov.
-#   - Tzeireh is spelled ei. Ex. Teiveis.
+#   - Tzeire is spelled ei. Ex. Teiveis.
 #   - Dipthongs into Yud spell the Yud with an i. Ex. Vaichi.
 #   - Cholom is spelled with an o. Ex. Bo, B'choros.
 #   - Komatz is spelled with an o,
@@ -38,7 +38,7 @@
 #     Ex. B'rachos, but Yom HaAtzma'ut.
 #   - Sof at the beginning of a grammatical unit turns into a Tof
 #     and is spelled with a t.
-#     Ex. Ki Seitzei, but Tazria; Tammuz, but Shivo Osor B'Sammuz.
+#     Ex. Ki Seitzei, but Tazri'a; Tammuz, but Shivo Osor B'Sammuz.
 #   - Consonants are doubled, if doubled in the en locale.
 #     Ex. Bovo Kammo, Tammuz.
 #
@@ -579,7 +579,7 @@ msgid "Tammuz"
 msgstr "Tammuz"
 
 msgid "Tazria"
-msgstr "Tazria"
+msgstr "Tazri'a"
 
 msgid "Temurah"
 msgstr "T'muro"


### PR DESCRIPTION
~~WIP: I'm working on creating a new locale, `ashkenazi_consonants`, based off of `ashkenazi_standard`. As I work through the comments and strings, I've been noticing some little fixes that need to be made.~~

~~This will exit WIP/draft mode when I've completed `ashkenazi_consonants` on my local.~~

- fix(ashkenazi_standard): fix trailing h in comments, Tazria->Tazri'a
- fix(ashkenazi_standard): rm duplicate Chatzot hayom
- feat(ashkenazi_standard): tzeireh is ei only on long and stressed vowels, otherwise e
- fix(ashkenazi_standard): overwhelmingly not pronounced Sh'vot->Shvot
- docs(ashkenazi_standard): comments only