### PR TITLE
Add Ashkenazi dialect transliterations for Rosh Hashana LaBehemot

### DIFF
--- a/po/ashkenazi_komatz.po
+++ b/po/ashkenazi_komatz.po
@@ -453,6 +453,9 @@ msgstr "Rosh Hashono I"
 msgid "Rosh Hashana II"
 msgstr "Rosh Hashono II"
 
+msgid "Rosh Hashana LaBehemot"
+msgstr "Rosh Hashono LaBeheimos"
+
 msgid "Sanhedrin"
 msgstr "Sanhedrin"
 

--- a/po/ashkenazi_litvish.po
+++ b/po/ashkenazi_litvish.po
@@ -504,6 +504,9 @@ msgstr "Reish Hashono I"
 msgid "Reish Hashana II"
 msgstr "Reish Hashono II"
 
+msgid "Rosh Hashana LaBehemot"
+msgstr "Reish Hashono LaBeheimos"
+
 msgid "Shabbat Chazon"
 msgstr "Shabbos Chazon"
 

--- a/po/ashkenazi_poylish.po
+++ b/po/ashkenazi_poylish.po
@@ -508,6 +508,9 @@ msgstr "Rosh Hashono I"
 msgid "Rosh Hashana II"
 msgstr "Rosh Hashono II"
 
+msgid "Rosh Hashana LaBehemot"
+msgstr "Rosh Hashono LaBeheimos"
+
 msgid "Shabbat Chazon"
 msgstr "Shabbos Chazon"
 

--- a/po/ashkenazi_romanian.po
+++ b/po/ashkenazi_romanian.po
@@ -518,6 +518,9 @@ msgstr "Roş Haşono I"
 msgid "Rosh Hashana II"
 msgstr "Roş Haşono II"
 
+msgid "Rosh Hashana LaBehemot"
+msgstr "Roş Haşono LaBeheimos"
+
 msgid "Shabbat Chazon"
 msgstr "Şavos Ĥazon"
 

--- a/po/ashkenazi_standard.po
+++ b/po/ashkenazi_standard.po
@@ -451,6 +451,9 @@ msgstr "Rosh Hashanah I"
 msgid "Rosh Hashana II"
 msgstr "Rosh Hashanah II"
 
+msgid "Rosh Hashana LaBehemot"
+msgstr "Rosh Hashanah LaBeheimos"
+
 msgid "Sanhedrin"
 msgstr "Sanhedrin"
 


### PR DESCRIPTION
Adds the missing entry for `Rosh Hashana LaBehemot` to all five Ashkenazi dialect locales:

Each follows the existing vowel conventions of its locale (Rosh/Reish for cholam, Hashana/Hashanah/Hashono/Haşono for kamatz/final-hei; ei for tzeirei throughout).