### PR TITLE
Fix ashkenazi_litvish msgids that used dialect form

### DIFF
--- a/po/ashkenazi_litvish.po
+++ b/po/ashkenazi_litvish.po
@@ -387,7 +387,7 @@ msgstr "Erev Peisach"
 msgid "Erev Purim"
 msgstr "Erev Purim"
 
-msgid "Erev Reish Hashana"
+msgid "Erev Rosh Hashana"
 msgstr "Erev Reish-Hashono"
 
 msgid "Erev Shavuot"
@@ -453,7 +453,7 @@ msgstr "Purim"
 msgid "Purim Katan"
 msgstr "Purim Koton"
 
-msgid "Reish Chodesh %s"
+msgid "Rosh Chodesh %s"
 msgstr "Reish Cheidesh %s"
 
 msgid "Adar"
@@ -495,13 +495,13 @@ msgstr "Tamuz"
 msgid "Tevet"
 msgstr "Teyves"
 
-msgid "Reish Hashana"
+msgid "Rosh Hashana"
 msgstr "Reish Hashono"
 
-msgid "Reish Hashana I"
+msgid "Rosh Hashana I"
 msgstr "Reish Hashono I"
 
-msgid "Reish Hashana II"
+msgid "Rosh Hashana II"
 msgstr "Reish Hashono II"
 
 msgid "Shabbat Chazon"
@@ -522,7 +522,7 @@ msgstr "Shabbos Nachamu"
 msgid "Shabbat Parah"
 msgstr "Shabbos Poro"
 
-msgid "Shabbat Reish Chodesh"
+msgid "Shabbat Rosh Chodesh"
 msgstr "Shabbos Reish Cheidesh"
 
 msgid "Shabbat Shekalim"

--- a/test/gettext.spec.js
+++ b/test/gettext.spec.js
@@ -14,6 +14,10 @@ test('ro', (t) => {
   t.is(Locale.gettext('Pesach I', 'ro'), 'Pesaĥ I');
 });
 
+test('ashkenazi_litvish', (t) => {
+  t.is(Locale.gettext('Rosh Hashana', 'ashkenazi_litvish'), 'Reish Hashono');
+});
+
 test('ashkenazi_romanian', (t) => {
   t.is(Locale.gettext('Pesach I', 'ashkenazi_romanian'), 'Peisaĥ I');
 });


### PR DESCRIPTION
Six `msgid` keys in `po/ashkenazi_litvish.po` were written in the transliterated Litvish form (e.g. `"Reish Hashana"`) instead of the canonical English source string. Since `Locale.gettext()` does a flat key lookup with no cross-locale fallback, these entries were silently dead and callers received the untranslated English fallback instead of the intended Litvish transliteration. The `msgstr` values are correct and unchanged. Regression test added.

Trace:
`hebcal/hebcal-es6/src/locale.ts` calls `Locale.addTranslations(...)` and then re-exports. `Locale` lives at `hebcal/hdate-js/src/locale.ts`: `gettext` -> `lookupTranslation` resolves `loc` via `locales.get(checkLocale(locale))`, then does `loc[id]`. In all Reish <-> Rosh cases the locale is registered, so `loc` correctly points to the litvish context map. `loc[id]` returns `undefined` because `id` is `"Rosh Hashana"` but the key in the map is `"Reish Hashana"`. `gettext` then returns the raw `id`, i.e. the untranslated English string.